### PR TITLE
filter out non existing relations

### DIFF
--- a/src/build/buildDataObjects.js
+++ b/src/build/buildDataObjects.js
@@ -100,7 +100,7 @@ const buildDataObjects = async ({
               return;
             }
             return relatedRecord.id;
-          });
+          }).filter(id => id);
           break;
         }
       }


### PR DESCRIPTION
fixes e.g.
> Error: Invariant Violation: Encountered an error trying to infer a GraphQL type for: `Authors___NODE`. There is no corresponding node with the `id` field matching: "undefined".
in gatsby 2.19.18